### PR TITLE
Fixed a bug with the cache clear feature.

### DIFF
--- a/sointuexemsx/__main__.py
+++ b/sointuexemsx/__main__.py
@@ -141,7 +141,7 @@ if __name__ == '__main__':
     if args.forceDownload:
         print("Clearing cache.")
         for url in downloadUrls.values():
-            for deletedPath in clear_cached_path(url.value):
+            for deletedPath in clear_cached_path(url):
                 print(f"Removing {deletedPath}")
 
     programs = {}


### PR DESCRIPTION
This problem here.
```
Clearing cache.
Traceback (most recent call last):
File "__main__.py", line 144, in <module>
for deletedPath in clear_cached_path(url.value):
                                         ^^^^^^^^^
AttributeError: 'str' object has no attribute 'value'
[PYI-2668:ERROR] Failed to execute script '__main__' due to unhandled exception!
```